### PR TITLE
fix: resolve staging terraform state issues and update IAM permissions

### DIFF
--- a/cloudformation/github-actions-role.yml
+++ b/cloudformation/github-actions-role.yml
@@ -94,6 +94,7 @@ Resources:
                   - kms:CreateKey
                   - kms:CreateAlias
                   - kms:DeleteAlias
+                  - kms:UpdateAlias
                   - kms:DescribeKey
                   - kms:Describe*
                   - kms:EnableKeyRotation
@@ -151,6 +152,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:DeleteLogGroup
                   - logs:DescribeLogGroups
+                  - logs:AssociateKmsKey
                   - logs:CreateLogDelivery
                   - logs:GetLogDelivery
                   - logs:UpdateLogDelivery

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -184,7 +184,7 @@ module "ecr" {
   repository_name      = "${var.app_name}-${var.environment}-lambda"
   environment          = var.environment
   kms_key_arn          = aws_kms_key.main.arn
-  force_delete         = false
+  force_delete         = true
   image_tag_mutability = "MUTABLE" # Allow overwriting 'latest' tag for easier iteration
 
   tags = local.tags

--- a/terraform/modules/iam/main.tf
+++ b/terraform/modules/iam/main.tf
@@ -104,6 +104,17 @@ resource "aws_iam_policy" "lambda_combined" {
           "textract:GetDocumentAnalysis"
         ]
         Resource = "*"
+      },
+      # ECR access for container images
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage"
+        ]
+        Resource = "arn:aws:ecr:${var.region}:${var.account_id}:repository/${var.app_name}-${var.environment}-lambda"
       }
     ]
   })


### PR DESCRIPTION
## Summary
- Add ECR permissions to IAM module for Lambda access
- Enable force_delete for ECR repository in staging  
- Add kms:UpdateAlias and logs:AssociateKmsKey to GitHub Actions role
- Update CloudFormation template with missing permissions

## Changes
- `terraform/main.tf`: Enable force_delete for ECR
- `terraform/modules/iam/main.tf`: Add ECR permissions to Lambda IAM policy
- `cloudformation/github-actions-role.yml`: Add missing KMS and CloudWatch Logs permissions